### PR TITLE
Fixed role name reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following variables are set to `False` by default and will not have any effe
 ```yaml
 - hosts: all
   roles:
-    - kamaln7.swapfile
+    - viasite-ansible.swapfile
 ```
 
 or:
@@ -42,7 +42,7 @@ or:
 ```yaml
 - hosts: all
   roles:
-    - { role: kamaln7.swapfile, swapfile_size: 1GB, swapfile_swappiness: 10, swapfile_location: /mnt/swapfile }
+    - { role: viasite-ansible.swapfile, swapfile_size: 1GB, swapfile_swappiness: 10, swapfile_location: /mnt/swapfile }
 ```
 
 You can also set the variables described above in `group_vars` or `host_vars` (see `defaults/main.yml`).


### PR DESCRIPTION
The role name in the README file was referencing the upstream role name and not the one that gets installed when running `ansible-galaxy install viasite-ansible.swapfile`